### PR TITLE
Update Node engines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,9 @@
       },
       "devDependencies": {
         "prettier-plugin-astro": "^0.13.0"
+      },
+      "engines": {
+        "node": "18.x"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
   },
   "devDependencies": {
     "prettier-plugin-astro": "^0.13.0"
+  },
+  "engines": {
+    "node": "18.x"
   }
 }


### PR DESCRIPTION
## Summary
- set engine to Node 18.x in `package.json`
- keep package-lock in sync

## Testing
- `npm install` *(fails: Unsupported engine and network issues)*
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_68404a1e4d6c83208805accb0d5dd4e5